### PR TITLE
Add support for PostgreSQL

### DIFF
--- a/examples/psql/README.md
+++ b/examples/psql/README.md
@@ -1,0 +1,22 @@
+## Schema
+
+See [schema.sql](schema.sql) for the example schema.
+
+## Usage
+
+Define PostgreSQL connection details via environment variables:
+
+```bash
+export POSTGRES_HOSTNAME=...
+export POSTGRES_USERNAME=...
+export POSTGRES_PASSWORD=...
+export POSTGRES_DATABASE=...
+```
+
+or in `hunter.yaml`.
+
+The following command shows results for a single test `aggregate_mem` and updates the database with newly found change points:
+
+```bash
+$ BRANCH=trunk HUNTER_CONFIG=hunter.yaml hunter analyze aggregate_mem --update-postgres
+```

--- a/examples/psql/hunter.yaml
+++ b/examples/psql/hunter.yaml
@@ -1,0 +1,55 @@
+# External systems connectors configuration:
+postgres:
+  hostname: ${POSTGRES_HOSTNAME}
+  port: ${POSTGRES_PORT}
+  username: ${POSTGRES_USERNAME}
+  password: ${POSTGRES_PASSWORD}
+  database: ${POSTGRES_DATABASE}
+
+# Templates define common bits shared between test definitions:
+templates:
+  common:
+    type: postgres
+    time_column: commit_ts
+    attributes: [experiment_id, config_id, commit]
+    # required for --update-postgres to work
+    update_statement: |
+      UPDATE results 
+        SET {metric}_rel_forward_change=%s, 
+            {metric}_rel_backward_change=%s, 
+            {metric}_p_value=%s
+      WHERE experiment_id = '{experiment_id}' AND config_id = {config_id}
+    metrics:
+      process_cumulative_rate_mean:
+        direction: 1
+        scale: 1
+      process_cumulative_rate_stderr:
+        direction: -1
+        scale: 1
+      process_cumulative_rate_diff:
+        direction: -1
+        scale: 1
+
+# Define your tests here:
+tests:
+  aggregate_mem:
+    inherit: [ common ] # avoids repeating metrics definitions and postgres-related config
+    query: |
+      SELECT e.commit, 
+             e.commit_ts, 
+             r.process_cumulative_rate_mean, 
+             r.process_cumulative_rate_stderr, 
+             r.process_cumulative_rate_diff, 
+             r.experiment_id, 
+             r.config_id
+      FROM results r
+      INNER JOIN configs c ON r.config_id = c.id
+      INNER JOIN experiments e ON r.experiment_id = e.id
+      WHERE e.exclude_from_analysis = false AND
+            e.branch = '${BRANCH}' AND
+            e.username = 'ci' AND
+            c.store = 'MEM' AND
+            c.cache = true AND
+            c.benchmark = 'aggregate' AND
+            c.instance_type = 'ec2i3.large'
+      ORDER BY e.commit_ts ASC;

--- a/examples/psql/schema.sql
+++ b/examples/psql/schema.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS configs (
+    id SERIAL PRIMARY KEY,
+    benchmark TEXT NOT NULL,
+    scenario TEXT NOT NULL,
+    store TEXT NOT NULL,
+    instance_type TEXT NOT NULL,
+    cache BOOLEAN NOT NULL,
+    UNIQUE(benchmark,
+           scenario,
+           store,
+           cache,
+           instance_type)
+);
+
+CREATE TABLE IF NOT EXISTS experiments (
+    id TEXT PRIMARY KEY,
+    ts TIMESTAMPTZ NOT NULL,
+    branch TEXT NOT NULL,
+    commit TEXT NOT NULL,
+    commit_ts TIMESTAMPTZ NOT NULL,
+    username TEXT NOT NULL,
+    details_url TEXT NOT NULL,
+    exclude_from_analysis BOOLEAN DEFAULT false NOT NULL,
+    exclude_reason TEXT
+);
+
+CREATE TABLE IF NOT EXISTS results (
+  experiment_id TEXT NOT NULL REFERENCES experiments(id),
+  config_id INTEGER NOT NULL REFERENCES configs(id),
+
+  process_cumulative_rate_mean BIGINT NOT NULL,
+  process_cumulative_rate_stderr BIGINT NOT NULL,
+  process_cumulative_rate_diff BIGINT NOT NULL,
+
+  process_cumulative_rate_mean_rel_forward_change DOUBLE PRECISION,
+  process_cumulative_rate_mean_rel_backward_change DOUBLE PRECISION,
+  process_cumulative_rate_mean_p_value DECIMAL,
+
+  process_cumulative_rate_stderr_rel_forward_change DOUBLE PRECISION,
+  process_cumulative_rate_stderr_rel_backward_change DOUBLE PRECISION,
+  process_cumulative_rate_stderr_p_value DECIMAL,
+
+  process_cumulative_rate_diff_rel_forward_change DOUBLE PRECISION,
+  process_cumulative_rate_diff_rel_backward_change DOUBLE PRECISION,
+  process_cumulative_rate_diff_p_value DECIMAL,
+
+  PRIMARY KEY (experiment_id, config_id)
+);

--- a/hunter/config.py
+++ b/hunter/config.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML
 
 from hunter.grafana import GrafanaConfig
 from hunter.graphite import GraphiteConfig
+from hunter.postgres import PostgresConfig
 from hunter.slack import SlackConfig
 from hunter.test_config import TestConfig, create_test_config
 from hunter.util import merge_dict_list
@@ -20,6 +21,7 @@ class Config:
     tests: Dict[str, TestConfig]
     test_groups: Dict[str, List[TestConfig]]
     slack: SlackConfig
+    postgres: PostgresConfig
 
 
 @dataclass
@@ -110,6 +112,27 @@ def load_config_from(config_file: Path) -> Config:
                 bot_token=config["slack"]["token"],
             )
 
+        postgres_config = None
+        if config.get("postgres") is not None:
+            if not config["postgres"]["hostname"]:
+                raise ValueError("postgres.hostname")
+            if not config["postgres"]["port"]:
+                raise ValueError("postgres.port")
+            if not config["postgres"]["username"]:
+                raise ValueError("postgres.username")
+            if not config["postgres"]["password"]:
+                raise ValueError("postgres.password")
+            if not config["postgres"]["database"]:
+                raise ValueError("postgres.database")
+
+            postgres_config = PostgresConfig(
+                hostname=config["postgres"]["hostname"],
+                port=config["postgres"]["port"],
+                username=config["postgres"]["username"],
+                password=config["postgres"]["password"],
+                database=config["postgres"]["database"],
+            )
+
         templates = load_templates(config)
         tests = load_tests(config, templates)
         groups = load_test_groups(config, tests)
@@ -118,6 +141,7 @@ def load_config_from(config_file: Path) -> Config:
             graphite=graphite_config,
             grafana=grafana_config,
             slack=slack_config,
+            postgres=postgres_config,
             tests=tests,
             test_groups=groups,
         )

--- a/hunter/importer.py
+++ b/hunter/importer.py
@@ -9,12 +9,15 @@ from typing import Dict, List, Optional
 from hunter.config import Config
 from hunter.data_selector import DataSelector
 from hunter.graphite import DataPoint, Graphite, GraphiteError
+from hunter.postgres import Postgres
 from hunter.series import Metric, Series
 from hunter.test_config import (
     CsvMetric,
     CsvTestConfig,
     GraphiteTestConfig,
     HistoStatTestConfig,
+    PostgresMetric,
+    PostgresTestConfig,
     TestConfig,
 )
 from hunter.util import (
@@ -431,17 +434,122 @@ class HistoStatImporter(Importer):
         return metric_names
 
 
+class PostgresImporter:
+    __postgres: Postgres
+
+    def __init__(self, postgres: Postgres):
+        self.__postgres = postgres
+
+    @staticmethod
+    def __selected_metrics(
+        defined_metrics: Dict[str, PostgresMetric], selected_metrics: Optional[List[str]]
+    ) -> Dict[str, PostgresMetric]:
+
+        if selected_metrics is not None:
+            return {name: defined_metrics[name] for name in selected_metrics}
+        else:
+            return defined_metrics
+
+    def fetch_data(self, test_conf: TestConfig, selector: DataSelector = DataSelector()) -> Series:
+        if not isinstance(test_conf, PostgresTestConfig):
+            raise ValueError("Expected PostgresTestConfig")
+
+        if selector.branch:
+            raise ValueError("Postgres tests don't support branching yet")
+
+        since_time = selector.since_time
+        until_time = selector.until_time
+        if since_time.timestamp() > until_time.timestamp():
+            raise DataImportError(
+                f"Invalid time range: ["
+                f"{format_timestamp(int(since_time.timestamp()))}, "
+                f"{format_timestamp(int(until_time.timestamp()))}]"
+            )
+        metrics = self.__selected_metrics(test_conf.metrics, selector.metrics)
+
+        columns, rows = self.__postgres.fetch_data(test_conf.query)
+
+        # Decide which columns to fetch into which components of the result:
+        try:
+            time_index: int = columns.index(test_conf.time_column)
+            attr_indexes: List[int] = [columns.index(c) for c in test_conf.attributes]
+            metric_names = [m.name for m in metrics.values()]
+            metric_columns = [m.column for m in metrics.values()]
+            metric_indexes: List[int] = [columns.index(c) for c in metric_columns]
+        except ValueError as err:
+            raise DataImportError(f"Column not found {err.args[0]}")
+
+        time: List[int] = []
+        data: Dict[str, List[float]] = {}
+        for n in metric_names:
+            data[n] = []
+        attributes: Dict[str, List[str]] = {}
+        for i in attr_indexes:
+            attributes[columns[i]] = []
+
+        for row in rows:
+            ts: datetime = row[time_index]
+            if since_time is not None and ts < since_time:
+                continue
+            if until_time is not None and ts >= until_time:
+                continue
+            time.append(int(ts.timestamp()))
+
+            # Read metric values. Note we can still fail on conversion to float,
+            # because the user is free to override the column selection and thus
+            # they may select a column that contains non-numeric data:
+            for (name, i) in zip(metric_names, metric_indexes):
+                try:
+                    data[name].append(float(row[i]))
+                except ValueError as err:
+                    raise DataImportError(
+                        "Could not convert value in column " + columns[i] + ": " + err.args[0]
+                    )
+
+            # Attributes are just copied as-is, with no conversion:
+            for i in attr_indexes:
+                attributes[columns[i]].append(row[i])
+
+        # Convert metrics to series.Metrics
+        metrics = {m.name: Metric(m.direction, m.scale) for m in metrics.values()}
+
+        # Leave last n points:
+        time = time[-selector.last_n_points :]
+        tmp = data
+        data = {}
+        for k, v in tmp.items():
+            data[k] = v[-selector.last_n_points :]
+        tmp = attributes
+        attributes = {}
+        for k, v in tmp.items():
+            attributes[k] = v[-selector.last_n_points :]
+
+        return Series(
+            test_conf.name,
+            branch=None,
+            time=time,
+            metrics=metrics,
+            data=data,
+            attributes=attributes,
+        )
+
+    def fetch_all_metric_names(self, test_conf: PostgresTestConfig) -> List[str]:
+        return [m for m in test_conf.metrics.keys()]
+
+
 class Importers:
     __config: Config
     __csv_importer: Optional[CsvImporter]
     __graphite_importer: Optional[GraphiteImporter]
     __histostat_importer: Optional[HistoStatImporter]
+    __postgres_importer: Optional[PostgresImporter]
 
     def __init__(self, config: Config):
         self.__config = config
         self.__csv_importer = None
         self.__graphite_importer = None
         self.__histostat_importer = None
+        self.__postgres_importer = None
 
     def csv_importer(self) -> CsvImporter:
         if self.__csv_importer is None:
@@ -458,6 +566,11 @@ class Importers:
             self.__histostat_importer = HistoStatImporter()
         return self.__histostat_importer
 
+    def postgres_importer(self) -> PostgresImporter:
+        if self.__postgres_importer is None:
+            self.__postgres_importer = PostgresImporter(Postgres(self.__config.postgres))
+        return self.__postgres_importer
+
     def get(self, test: TestConfig) -> Importer:
         if isinstance(test, CsvTestConfig):
             return self.csv_importer()
@@ -465,5 +578,7 @@ class Importers:
             return self.graphite_importer()
         elif isinstance(test, HistoStatTestConfig):
             return self.histostat_importer()
+        elif isinstance(test, PostgresTestConfig):
+            return self.postgres_importer()
         else:
             raise ValueError(f"Unsupported test type {type(test)}")

--- a/hunter/importer.py
+++ b/hunter/importer.py
@@ -434,7 +434,7 @@ class HistoStatImporter(Importer):
         return metric_names
 
 
-class PostgresImporter:
+class PostgresImporter(Importer):
     __postgres: Postgres
 
     def __init__(self, postgres: Postgres):

--- a/hunter/importer.py
+++ b/hunter/importer.py
@@ -479,7 +479,7 @@ class PostgresImporter(Importer):
         except ValueError as err:
             raise DataImportError(f"Column not found {err.args[0]}")
 
-        time: List[int] = []
+        time: List[float] = []
         data: Dict[str, List[float]] = {}
         for n in metric_names:
             data[n] = []
@@ -493,7 +493,7 @@ class PostgresImporter(Importer):
                 continue
             if until_time is not None and ts >= until_time:
                 continue
-            time.append(int(ts.timestamp()))
+            time.append(ts.timestamp())
 
             # Read metric values. Note we can still fail on conversion to float,
             # because the user is free to override the column selection and thus

--- a/hunter/postgres.py
+++ b/hunter/postgres.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Dict
 
 import psycopg2
@@ -53,7 +54,8 @@ class Postgres:
         change_point: ChangePoint,
     ):
         cursor = self.__get_conn().cursor()
-        update_stmt = test.update_stmt.format(metric=metric_name, **attributes)
+        kwargs = {**attributes, **{test.time_column: datetime.utcfromtimestamp(change_point.time)}}
+        update_stmt = test.update_stmt.format(metric=metric_name, **kwargs)
         cursor.execute(
             update_stmt,
             (

--- a/hunter/postgres.py
+++ b/hunter/postgres.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+import psycopg2
+
+
+@dataclass
+class PostgresConfig:
+    hostname: str
+    port: int
+    username: str
+    password: str
+    database: str
+
+
+class Postgres:
+    __conn = None
+    __config = None
+
+    def __init__(self, config: PostgresConfig):
+        self.__config = config
+
+    def __get_conn(self) -> psycopg2.extensions.connection:
+        if self.__conn is None:
+            self.__conn = psycopg2.connect(
+                host=self.__config.hostname,
+                port=self.__config.port,
+                user=self.__config.username,
+                password=self.__config.password,
+                database=self.__config.database,
+            )
+        return self.__conn
+
+    def fetch_data(self, query: str):
+        cursor = self.__get_conn().cursor()
+        cursor.execute(query)
+        columns = [c.name for c in cursor.description]
+        return (columns, cursor.fetchall())

--- a/hunter/series.py
+++ b/hunter/series.py
@@ -71,7 +71,7 @@ class ChangePointGroup:
     """A group of change points on multiple metrics, at the same time"""
 
     index: int
-    time: int
+    time: float
     prev_time: int
     attributes: Dict[str, str]
     prev_attributes: Dict[str, str]

--- a/hunter/test_config.py
+++ b/hunter/test_config.py
@@ -132,6 +132,7 @@ class PostgresMetric:
 @dataclass
 class PostgresTestConfig(TestConfig):
     query: str
+    update_stmt: str
     time_column: str
     attributes: List[str]
     metrics: Dict[str, PostgresMetric]
@@ -140,6 +141,7 @@ class PostgresTestConfig(TestConfig):
         self,
         name: str,
         query: str,
+        update_stmt: str = "",
         time_column: str = "time",
         metrics: List[PostgresMetric] = None,
         attributes: List[str] = None,
@@ -149,6 +151,7 @@ class PostgresTestConfig(TestConfig):
         self.time_column = time_column
         self.metrics = {m.name: m for m in metrics} if metrics else {}
         self.attributes = attributes
+        self.update_stmt = update_stmt
 
     def fully_qualified_metric_names(self) -> List[str]:
         return list(self.metrics.keys())
@@ -269,6 +272,7 @@ def create_postgres_test_config(test_name: str, test_info: Dict) -> PostgresTest
         attributes = test_info.get("attributes", [])
         metrics_info = test_info.get("metrics")
         query = test_info["query"]
+        update_stmt = test_info.get("update_statement", "")
 
         metrics = []
         if isinstance(metrics_info, List):
@@ -287,6 +291,6 @@ def create_postgres_test_config(test_name: str, test_info: Dict) -> PostgresTest
         else:
             raise TestConfigError(f"Metrics of the test {test_name} must be a list or dictionary")
 
-        return PostgresTestConfig(test_name, query, time_column, metrics, attributes)
+        return PostgresTestConfig(test_name, query, update_stmt, time_column, metrics, attributes)
     except KeyError as e:
         raise TestConfigError(f"Configuration key not found in test {test_name}: {e.args[0]}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,6 +128,7 @@ calendars = ["hijri-converter", "convertdate"]
 fasttext = ["fasttext"]
 langdetect = ["langdetect"]
 
+
 [[package]]
 name = "decorator"
 version = "5.1.1"
@@ -293,8 +294,16 @@ optional = false
 python-versions = ">=3.8"
 
 [package.extras]
-dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.3"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [[package]]
 name = "py"
@@ -523,7 +532,6 @@ python-versions = ">=3.7"
 [[package]]
 name = "tox"
 version = "3.28.0"
-description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -665,6 +673,7 @@ packaging = []
 pathspec = []
 platformdirs = []
 pluggy = []
+psycopg2-binary = []
 py = []
 pycodestyle = []
 pyflakes = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ expandvars = "^0.6.5"
 numpy = "1.24"
 python = ">=3.8,<3.13"
 python-dateutil = "^2.8.1"
+psycopg2-binary = "^2.9.3"
 signal-processing-algorithms = "^1.3.2"
 "ruamel.yaml" = "=0.17.21"
 requests = "^2.25.1"
@@ -17,6 +18,7 @@ pystache = "^0.6.0"
 tabulate = "^0.8.7"
 validators = "^0.18.2"
 slack-sdk = "^3.4.2"
+
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -152,7 +152,7 @@ def test_import_postgres():
         attributes=["commit"],
     )
     importer = PostgresImporter(MockPostgres())
-    series = importer.fetch_data(test_conf=test)
+    series = importer.fetch_data(test_conf=test, selector=data_selector())
     assert len(series.data.keys()) == 2
     assert len(series.time) == 10
     assert len(series.data["m1"]) == 10
@@ -192,7 +192,7 @@ def test_import_postgres_last_n_points():
     )
 
     importer = PostgresImporter(MockPostgres())
-    selector = DataSelector()
+    selector = data_selector()
     selector.last_n_points = 5
     series = importer.fetch_data(test, selector=selector)
     assert len(series.time) == 5


### PR DESCRIPTION
Thank you for opensourcing hunter!

This PR adds support to using PostgreSQL as a data source for benchmark results. See the usage example below.

Configuration:

```yaml
postgres:
  hostname: ${POSTGRES_HOST}
  port: ${POSTGRES_PORT}
  username: ${POSTGRES_USERNAME}
  password: ${POSTGRES_PASSWORD}
  database: ${POSTGRES_DATABASED}
```

```yaml
templates:
  common:
    type: postgres
    time_column: ts
    attributes: [commit]
    metrics:
    ...
```

Test:

```yaml
  # trunk
  trunk.aggregate_mem:
    inherit: [common]
    query: |
      SELECT e.*
      FROM experiments e
      INNER JOIN setups s ON e.setup_id = s.id
      WHERE e.exclude_from_analysis = false AND
            e.branch = 'trunk' AND
            s.benchmark = 'aggregate' AND
            s.scenario = 'singleNode' AND
            s.suppress = 'NONE' AND
            s.store = 'MEM' AND
            s.cache = true AND
            s.log = true AND
            s.sink = false AND
            s.keyspace = 10000 AND
            s.key_distribution = 'normal' AND
            s.partitions = 2 AND
            s.instance_type = 'ec2i3.large'
      ORDER BY e.ts ASC;
```