### PR TITLE
Updating pipx install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use pyenv to install it.
 Use pipx to install hunter:
 
 ```
-pipx install git+ssh://git@github.com/datastax/hunter
+pipx install git+ssh://git@github.com/datastax-labs/hunter
 ```
 
 ## Setup


### PR DESCRIPTION
Updating the pipx install command with new ssh url in **Installation** section of the README file