### PR TITLE
Include more change point details in JSON output

### DIFF
--- a/hunter/analysis.py
+++ b/hunter/analysis.py
@@ -33,9 +33,38 @@ class ComparativeStats:
         """Relative change from right to left"""
         return self.mean_1 / self.mean_2 - 1.0
 
+    def forward_change_percent(self) -> float:
+        return self.forward_rel_change() * 100.0
+
+    def backward_change_percent(self) -> float:
+        return self.backward_rel_change() * 100.0
+
     def change_magnitude(self):
         """Maximum of absolutes of rel_change and rel_change_reversed"""
         return max(abs(self.forward_rel_change()), abs(self.backward_rel_change()))
+
+    def mean_before(self):
+        return self.mean_1
+
+    def mean_after(self):
+        return self.mean_2
+
+    def stddev_before(self):
+        return self.std_1
+
+    def stddev_after(self):
+        return self.std_2
+
+    def to_json(self):
+        return {
+            "forward_change_percent": f"{self.forward_change_percent():-0f}",
+            "magnitude": f"{self.change_magnitude():-0f}",
+            "mean_before": f"{self.mean_before():-0f}",
+            "stddev_before": f"{self.stddev_before():-0f}",
+            "mean_after": f"{self.mean_after():-0f}",
+            "stddev_after": f"{self.stddev_after():-0f}",
+            "pvalue": f"{self.pvalue:-0f}",
+        }
 
 
 @dataclass

--- a/hunter/series.py
+++ b/hunter/series.py
@@ -59,10 +59,31 @@ class ChangePoint:
     def magnitude(self):
         return self.stats.change_magnitude()
 
+    def mean_before(self):
+        return self.stats.mean_1
+
+    def mean_after(self):
+        return self.stats.mean_2
+
+    def stddev_before(self):
+        return self.stats.std_1
+
+    def stddev_after(self):
+        return self.stats.std_2
+
+    def pvalue(self):
+        return self.stats.pvalue
+
     def to_json(self):
         return {
             "metric": self.metric,
             "forward_change_percent": f"{self.forward_change_percent():.0f}",
+            "magnitude": f"{self.magnitude():-0f}",
+            "mean_before": f"{self.mean_before():-0f}",
+            "stddev_before": f"{self.stddev_before():-0f}",
+            "mean_after": f"{self.mean_after():-0f}",
+            "stddev_after": f"{self.stddev_after():-0f}",
+            "pvalue": f"{self.pvalue():-0f}",
         }
 
 

--- a/hunter/series.py
+++ b/hunter/series.py
@@ -99,7 +99,7 @@ class ChangePointGroup:
     changes: List[ChangePoint]
 
     def to_json(self):
-        return {"time": self.time, "changes": [cp.to_json() for cp in self.changes]}
+        return {"time": self.time, "attributes": self.attributes, "changes": [cp.to_json() for cp in self.changes]}
 
 
 class Series:


### PR DESCRIPTION
It's helpful for consumers of the JSON output to know things like the mean before/after and the pvalue when assessing the severity of a change in performance.