### PR TITLE
increment version from 0.5.0 to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hunter"
-version = "0.5.0"
+version = "0.6.0"
 description = ""
 authors = ["Piotr Kołaczkowski <pkolaczk@datastax.com>"]
 


### PR DESCRIPTION
Created a `v0.5.0` tag against 8ff166979d000780ad548e49f006ef2a15d54123 (https://github.com/datastax-labs/hunter/releases/tag/v0.5.0). Commits going forward should be considered part of the `0.6.0` line.