### PR TITLE
Make it easier to call hunter from scripts

### DIFF
--- a/hunter/main.py
+++ b/hunter/main.py
@@ -462,6 +462,16 @@ def analysis_options_from_args(args: argparse.Namespace) -> AnalysisOptions:
 
 
 def main():
+    try:
+        conf = config.load_config()
+    except ConfigError as err:
+        logging.error(err.message)
+        exit(1)
+
+    script_main(conf)
+
+
+def script_main(conf: Config):
     logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
     parser = argparse.ArgumentParser(description="Hunts performance regressions in Fallout results")
@@ -531,7 +541,6 @@ def main():
 
     try:
         args = parser.parse_args()
-        conf = config.load_config()
         hunter = Hunter(conf)
 
         if args.command == "list-groups":
@@ -619,9 +628,6 @@ def main():
         if args.command is None:
             parser.print_usage()
 
-    except ConfigError as err:
-        logging.error(err.message)
-        exit(1)
     except TestConfigError as err:
         logging.error(err.message)
         exit(1)

--- a/hunter/main.py
+++ b/hunter/main.py
@@ -471,7 +471,7 @@ def main():
     script_main(conf)
 
 
-def script_main(conf: Config):
+def script_main(conf: Config, args: List[str] = None):
     logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)
 
     parser = argparse.ArgumentParser(description="Hunts performance regressions in Fallout results")
@@ -540,7 +540,7 @@ def script_main(conf: Config):
     )
 
     try:
-        args = parser.parse_args()
+        args = parser.parse_args(args=args)
         hunter = Hunter(conf)
 
         if args.command == "list-groups":


### PR DESCRIPTION
Hunter is currently designed a cmdline tool only, but other Python scripts might want to invoke hunter programmatically.