### PR TITLE
Add more change point details to JSON output

### DIFF
--- a/hunter/analysis.py
+++ b/hunter/analysis.py
@@ -33,9 +33,38 @@ class ComparativeStats:
         """Relative change from right to left"""
         return self.mean_1 / self.mean_2 - 1.0
 
+    def forward_change_percent(self) -> float:
+        return self.forward_rel_change() * 100.0
+
+    def backward_change_percent(self) -> float:
+        return self.backward_rel_change() * 100.0
+
     def change_magnitude(self):
         """Maximum of absolutes of rel_change and rel_change_reversed"""
         return max(abs(self.forward_rel_change()), abs(self.backward_rel_change()))
+
+    def mean_before(self):
+        return self.mean_1
+
+    def mean_after(self):
+        return self.mean_2
+
+    def stddev_before(self):
+        return self.std_1
+
+    def stddev_after(self):
+        return self.std_2
+
+    def to_json(self):
+        return {
+            "forward_change_percent": f"{self.forward_change_percent():-0f}",
+            "magnitude": f"{self.change_magnitude():-0f}",
+            "mean_before": f"{self.mean_before():-0f}",
+            "stddev_before": f"{self.stddev_before():-0f}",
+            "mean_after": f"{self.mean_after():-0f}",
+            "stddev_after": f"{self.stddev_after():-0f}",
+            "pvalue": f"{self.pvalue:-0f}",
+        }
 
 
 @dataclass

--- a/hunter/series.py
+++ b/hunter/series.py
@@ -99,7 +99,11 @@ class ChangePointGroup:
     changes: List[ChangePoint]
 
     def to_json(self):
-        return {"time": self.time, "changes": [cp.to_json() for cp in self.changes]}
+        return {
+            "time": self.time,
+            "attributes": self.attributes,
+            "changes": [cp.to_json() for cp in self.changes],
+        }
 
 
 class Series:

--- a/hunter/series.py
+++ b/hunter/series.py
@@ -59,10 +59,31 @@ class ChangePoint:
     def magnitude(self):
         return self.stats.change_magnitude()
 
+    def mean_before(self):
+        return self.stats.mean_1
+
+    def mean_after(self):
+        return self.stats.mean_2
+
+    def stddev_before(self):
+        return self.stats.std_1
+
+    def stddev_after(self):
+        return self.stats.std_2
+
+    def pvalue(self):
+        return self.stats.pvalue
+
     def to_json(self):
         return {
             "metric": self.metric,
             "forward_change_percent": f"{self.forward_change_percent():.0f}",
+            "magnitude": f"{self.magnitude():-0f}",
+            "mean_before": f"{self.mean_before():-0f}",
+            "stddev_before": f"{self.stddev_before():-0f}",
+            "mean_after": f"{self.mean_after():-0f}",
+            "stddev_after": f"{self.stddev_after():-0f}",
+            "pvalue": f"{self.pvalue():-0f}",
         }
 
 

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -54,8 +54,38 @@ def test_json_report(report):
     obj = json.loads(output)
     expected = {
         "test_name_from_config": [
-            {"time": 4, "changes": [{"metric": "series2", "forward_change_percent": "-11"}]},
-            {"time": 6, "changes": [{"metric": "series1", "forward_change_percent": "-49"}]},
+            {
+                "time": 4,
+                "changes": [
+                    {
+                        "metric": "series2",
+                        "forward_change_percent": "-11",
+                        "magnitude": "0.124108",
+                        "mean_after": "1.801429",
+                        "mean_before": "2.025000",
+                        "pvalue": "0.000000",
+                        "stddev_after": "0.026954",
+                        "stddev_before": "0.011180",
+                    }
+                ],
+                "attributes": {},
+            },
+            {
+                "time": 6,
+                "changes": [
+                    {
+                        "metric": "series1",
+                        "forward_change_percent": "-49",
+                        "magnitude": "0.977513",
+                        "mean_after": "0.504000",
+                        "mean_before": "0.996667",
+                        "pvalue": "0.000000",
+                        "stddev_after": "0.025768",
+                        "stddev_before": "0.067495",
+                    }
+                ],
+                "attributes": {},
+            },
         ]
     }
     assert isinstance(obj, dict)


### PR DESCRIPTION
It's helpful for consumers of the JSON output to know things like the mean before/after and the pvalue when assessing the severity of a change in performance.