### PR TITLE
Check that all variables are defined in the config

### DIFF
--- a/hunter/config.py
+++ b/hunter/config.py
@@ -80,7 +80,7 @@ def load_test_groups(config: Dict, tests: Dict[str, TestConfig]) -> Dict[str, Li
 def load_config_from(config_file: Path) -> Config:
     """Loads config from the specified location"""
     try:
-        content = expandvars(config_file.read_text())
+        content = expandvars(config_file.read_text(), nounset=True)
         yaml = YAML(typ="safe")
         config = yaml.load(content)
         """

--- a/tests/resources/sample_config.yaml
+++ b/tests/resources/sample_config.yaml
@@ -1,8 +1,8 @@
 # Please place this file in `~/.hunter/hunter.yaml` and provide the missing config values:
 fallout:
   url: https://fallout.sjc.dsinternal.org/
-  user: ${FALLOUT_USER}
-  token: ${FALLOUT_OAUTH_TOKEN}
+  user: FALLOUT_USER
+  token: FALLOUT_OAUTH_TOKEN
 
 graphite:
   url: http://history.sjc.dsinternal.org/
@@ -17,8 +17,8 @@ graphite:
 
 grafana:
   url: http://history.datastax.lan:3000/
-  user: ${GRAFANA_USER}
-  password: ${GRAFANA_PASSWORD}
+  user: GRAFANA_USER
+  password: GRAFANA_PASSWORD
 
 # Templates define common bits shared between test definitions
 templates:


### PR DESCRIPTION
This change makes configuration parsing throw if at least one environmental variable is not set. This completely eliminates configuration hustle where you are not sure if all required variables are passed correctly.