### PR TITLE
Fix data location in csv example

### DIFF
--- a/examples/csv/docker-compose.yaml
+++ b/examples/csv/docker-compose.yaml
@@ -24,6 +24,4 @@ services:
     environment:
       OTAVA_CONFIG: examples/csv/otava.yaml
     volumes:
-      - ./tests:/tests
-
-
+      - ./data:/data

--- a/examples/csv/otava.yaml
+++ b/examples/csv/otava.yaml
@@ -18,10 +18,10 @@
 tests:
   local.sample:
     type: csv
-    file: /tests/local_sample.csv
+    file: /data/local_sample.csv
     time_column: time
     attributes: [commit]
     metrics: [metric1, metric2]
     csv_options:
-      delimiter: ','
+      delimiter: ","
       quotechar: "'"


### PR DESCRIPTION
Without this PR:

```
$ docker-compose -f examples/csv/docker-compose.yaml run --build otava bin/otava analyze local.sample
...
Error response from daemon: error while creating mount source path '/Users/asorokoumov/Projects/otava/examples/csv/tests': chown /Users/asorokoumov/Projects/otava/examples/csv/tests: permission denied
```

With this PR:

```
$ docker-compose -f examples/csv/docker-compose.yaml run --build otava bin/otava analyze local.sample
...
Computing change points for test local.sample...
time                       commit      metric1    metric2
-------------------------  --------  ---------  ---------
2025-01-01 02:00:00 +0000  aaa0         154023      10.43
2025-01-02 02:00:00 +0000  aaa1         138455      10.23
2025-01-03 02:00:00 +0000  aaa2         143112      10.29
2025-01-04 02:00:00 +0000  aaa3         149190      10.91
2025-01-05 02:00:00 +0000  aaa4         132098      10.34
2025-01-06 02:00:00 +0000  aaa5         151344      10.69
                                                ·········
                                                   -12.9%
                                                ·········
2025-01-07 02:00:00 +0000  aaa6         155145       9.23
2025-01-08 02:00:00 +0000  aaa7         148889       9.11
2025-01-09 02:00:00 +0000  aaa8         149466       9.13
2025-01-10 02:00:00 +0000  aaa9         148209       9.03
```