### PR TITLE
Add explicit read-only permissions to Python CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,6 +26,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add an explicit workflow `permissions` block to `.github/workflows/python-app.yml`.
- Set the token scope to `contents: read`.

## Why
The Python CI workflow only needs repository read access for checkout/build/test operations. Explicit least-privilege permissions harden the workflow and avoid relying on broad default token scopes.